### PR TITLE
expose location-overrides for modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/src/models/catalogModifier.ts
+++ b/src/models/catalogModifier.ts
@@ -1,4 +1,5 @@
 import {
+  array,
   lazy,
   nullable,
   number,
@@ -8,6 +9,30 @@ import {
   string,
 } from '../schema';
 import { Money, moneySchema } from './money';
+
+
+export interface ModifierLocationOverrides {
+  /** The ID of the `Location`. This can include locations that are deactivated. */
+  locationId?: string | null;
+  /**
+   * Represents an amount of money. `Money` fields can be signed or unsigned.
+   * Fields that do not explicitly define whether they are signed or unsigned are
+   * considered unsigned and can only hold positive amounts. For signed fields, the
+   * sign of the value indicates the purpose of the money transfer. See
+   * [Working with Monetary Amounts](https://developer.squareup.com/docs/build-basics/working-with-monetary-amounts)
+   * for more information.
+   */
+  priceMoney?: Money;
+}
+
+export const modifierLocationOverridesSchema: Schema<ModifierLocationOverrides> = object(
+  {
+    locationId: ['location_id', optional(nullable(string()))],
+    priceMoney: ['price_money', optional(lazy(() => moneySchema))],
+    pricingType: ['pricing_type', optional(string())]
+  }
+);
+
 
 /** A modifier applicable to items at the time of sale. */
 export interface CatalogModifier {
@@ -31,6 +56,7 @@ export interface CatalogModifier {
    * Currently this image is not displayed by Square, but is free to be displayed in 3rd party applications.
    */
   imageId?: string | null;
+  locationOverrides?: ModifierLocationOverrides[] | null;
 }
 
 export const catalogModifierSchema: Schema<CatalogModifier> = object({
@@ -39,4 +65,8 @@ export const catalogModifierSchema: Schema<CatalogModifier> = object({
   ordinal: ['ordinal', optional(nullable(number()))],
   modifierListId: ['modifier_list_id', optional(nullable(string()))],
   imageId: ['image_id', optional(nullable(string()))],
+  locationOverrides: [
+    'location_overrides',
+    optional(nullable(array(lazy(() => modifierLocationOverridesSchema)))),
+  ],  
 });


### PR DESCRIPTION
This PR changes the modifier schema in the catalog API so that the `location_overrides` field is exposed.
We need location_overrides to get the correct modifier pricing at a location.