### PR TITLE
Update publish workflow

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,6 +2,7 @@
 
 README.md
 
+.github/workflows/ci.yml
 .github/workflows/integration.yml
 src/wrapper
 src/index.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn && yarn test    
 
   publish:
-    needs: [ compile, test ]
+    needs: [ compile ]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This updates the `.github/workflows/ci.yml` job in a couple ways:
1. Add to `.fernignore` so that it's not updated when we regenerate the SDK.
2. Update the `publish` job to not require `test`.
    * This makes it possible to publish the SDK even if integration tests fail (i.e. if the tests are flaky).