### PR TITLE
security: replace hardcoded OAuth credentials with placeholders

### DIFF
--- a/src/api/resources/oAuth/client/Client.ts
+++ b/src/api/resources/oAuth/client/Client.ts
@@ -140,9 +140,9 @@ export class OAuthClient {
      *
      * @example
      *     await client.oAuth.obtainToken({
-     *         clientId: "sq0idp-uaPHILoPzWZk3tlJqlML0g",
-     *         clientSecret: "sq0csp-30a-4C_tVOnTh14Piza2BfTPBXyLafLPWSzY1qAjeBfM",
-     *         code: "sq0cgb-l0SBqxs4uwxErTVyYOdemg",
+     *         clientId: "YOUR_CLIENT_ID",
+     *         clientSecret: "YOUR_CLIENT_SECRET",
+     *         code: "YOUR_AUTHORIZATION_CODE",
      *         grantType: "authorization_code"
      *     })
      */

--- a/src/api/resources/oAuth/client/requests/ObtainTokenRequest.ts
+++ b/src/api/resources/oAuth/client/requests/ObtainTokenRequest.ts
@@ -3,9 +3,9 @@
 /**
  * @example
  *     {
- *         clientId: "sq0idp-uaPHILoPzWZk3tlJqlML0g",
- *         clientSecret: "sq0csp-30a-4C_tVOnTh14Piza2BfTPBXyLafLPWSzY1qAjeBfM",
- *         code: "sq0cgb-l0SBqxs4uwxErTVyYOdemg",
+ *         clientId: "YOUR_CLIENT_ID",
+ *         clientSecret: "YOUR_CLIENT_SECRET",
+ *         code: "YOUR_AUTHORIZATION_CODE",
  *         grantType: "authorization_code"
  *     }
  */

--- a/tests/wire/oAuth.test.ts
+++ b/tests/wire/oAuth.test.ts
@@ -43,9 +43,9 @@ describe("OAuthClient", () => {
         const server = mockServerPool.createServer();
         const client = new SquareClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
         const rawRequestBody = {
-            client_id: "sq0idp-uaPHILoPzWZk3tlJqlML0g",
-            client_secret: "sq0csp-30a-4C_tVOnTh14Piza2BfTPBXyLafLPWSzY1qAjeBfM",
-            code: "sq0cgb-l0SBqxs4uwxErTVyYOdemg",
+            client_id: "YOUR_CLIENT_ID",
+            client_secret: "YOUR_CLIENT_SECRET",
+            code: "YOUR_AUTHORIZATION_CODE",
             grant_type: "authorization_code",
         };
         const rawResponseBody = {
@@ -72,9 +72,9 @@ describe("OAuthClient", () => {
             .build();
 
         const response = await client.oAuth.obtainToken({
-            clientId: "sq0idp-uaPHILoPzWZk3tlJqlML0g",
-            clientSecret: "sq0csp-30a-4C_tVOnTh14Piza2BfTPBXyLafLPWSzY1qAjeBfM",
-            code: "sq0cgb-l0SBqxs4uwxErTVyYOdemg",
+            clientId: "YOUR_CLIENT_ID",
+            clientSecret: "YOUR_CLIENT_SECRET",
+            code: "YOUR_AUTHORIZATION_CODE",
             grantType: "authorization_code",
         });
         expect(response).toEqual({


### PR DESCRIPTION
## Summary

Replaces real Square OAuth credentials (client ID `sq0idp-*`, client secret `sq0csp-*`, authorization code `sq0cgb-*`) found in JSDoc examples and test fixtures with descriptive placeholders (`YOUR_CLIENT_ID`, `YOUR_CLIENT_SECRET`, `YOUR_AUTHORIZATION_CODE`).

## Why This Matters

Even in documentation and test code, real credentials pose risks:
- **Credential stuffing**: Attackers harvest credentials from public repos to test against live APIs
- **Accidental use**: Developers may copy-paste example code with real credentials into production
- **Secret scanning**: These trigger alerts in GitHub secret scanning and third-party tools

## Files Changed

- `src/api/resources/oAuth/client/requests/ObtainTokenRequest.ts` — JSDoc example
- `src/api/resources/oAuth/client/Client.ts` — JSDoc example  
- `tests/wire/oAuth.test.ts` — Test fixtures

Found by [UNA](https://hello-una.ai), an autonomous AI security auditor.