### PR TITLE
feat(package): expose subpath exports for lighter consumer imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ await client.payments.create({
 });
 ```
 
+### Subpath imports
+
+For applications where startup latency matters (serverless cold starts, autoscaling
+boots, etc.), the SDK exposes its internal modules as package subpaths so consumers
+can avoid loading the full surface — including the ~1,300 runtime serialization
+schemas — when they only need a slice of it.
+
+```typescript
+// Just the type definitions for a single resource — no runtime schemas loaded.
+import type { Payment, Money } from "square/api/types/Payment";
+
+// Just one resource client.
+import { PaymentsClient } from "square/api/resources/payments";
+
+// Just the runtime serialization for a single model, e.g. for a custom worker
+// that needs to (de)serialize Square payloads without booting the client.
+import { Payment as PaymentSchema } from "square/serialization/types/Payment";
+
+// Just the SDK entry-point class and constants.
+import { SquareClient } from "square/Client";
+import { SquareEnvironment } from "square/environments";
+```
+
+The default `import { SquareClient } from "square"` entry continues to re-export the
+full surface and remains the recommended import for typical usage.
+
 ## Legacy SDK
 
 ## Legacy SDK

--- a/package.json
+++ b/package.json
@@ -69,6 +69,51 @@
     },
     "exports": {
         ".": "./index.js",
+        "./api": {
+            "types": "./api/index.d.ts",
+            "default": "./api/index.js"
+        },
+        "./api/resources/*": {
+            "types": "./api/resources/*/index.d.ts",
+            "default": "./api/resources/*/index.js"
+        },
+        "./api/types/*": {
+            "types": "./api/types/*.d.ts",
+            "default": "./api/types/*.js"
+        },
+        "./serialization": {
+            "types": "./serialization/index.d.ts",
+            "default": "./serialization/index.js"
+        },
+        "./serialization/resources/*": {
+            "types": "./serialization/resources/*/index.d.ts",
+            "default": "./serialization/resources/*/index.js"
+        },
+        "./serialization/types/*": {
+            "types": "./serialization/types/*.d.ts",
+            "default": "./serialization/types/*.js"
+        },
+        "./Client": {
+            "types": "./Client.d.ts",
+            "default": "./Client.js"
+        },
+        "./BaseClient": {
+            "types": "./BaseClient.d.ts",
+            "default": "./BaseClient.js"
+        },
+        "./environments": {
+            "types": "./environments.d.ts",
+            "default": "./environments.js"
+        },
+        "./errors": {
+            "types": "./errors/index.d.ts",
+            "default": "./errors/index.js"
+        },
+        "./version": {
+            "types": "./version.d.ts",
+            "default": "./version.js"
+        },
+        "./package.json": "./package.json",
         "./legacy": {
             "types": "./legacy/exports/index.d.ts",
             "require": {


### PR DESCRIPTION
Closes #237.

## The problem

The default `import { SquareClient } from 'square'` entry transitively loads every API resource client, every Fern-generated type module, and the ~1,300 runtime serialization schemas under `serialization/types/`. On boot-sensitive workloads (serverless cold starts, autoscaling instances) the total dominates startup time — the issue reporter measured ~600 ms just from `require('square')` on an M3 MacBook Air, with `serialization/index.js` alone accounting for 12 % of the boot path.

The SDK's surface is already split across small directories at the package root after `prepack` copies `dist/.` over (`./api/`, `./serialization/`, `./Client.js`, `./environments.js`, `./errors/`), but the `exports` map only publishes `.` and `./legacy`, so consumers who want to opt out can't reach the internal modules through a supported path.

## The change

Add subpath entries — each with a `types` mapping so TypeScript's `nodenext` / `bundler` resolvers find the declarations — that let consumers import only the slice they need:

```ts
// Just the type definitions for a single resource — no runtime schemas loaded.
import type { Payment } from 'square/api/types/Payment';

// Just one resource client.
import { PaymentsClient } from 'square/api/resources/payments';

// Just the runtime serialization for a single model.
import { Payment as PaymentSchema } from 'square/serialization/types/Payment';

// Just the SDK entry-point class and constants.
import { SquareClient } from 'square/Client';
import { SquareEnvironment } from 'square/environments';
```

The default `import { SquareClient } from 'square'` entry is **unchanged** and remains the recommended import for typical usage — the new entries are strictly additive, no existing call site changes shape.

README gets a short `### Subpath imports` subsection under `## Usage` pointing at the new import paths and the cold-start motivation, so the next person reading the docs after a `wiz` / `lighthouse` / cold-start profile knows the supported escape hatch.

## What this doesn't do

This doesn't make the default `square` entry itself faster — the eager re-exports in `src/index.ts` and the Fern-generated cascade still pull in everything. That looks like a separate (and bigger) discussion about how the generator structures the umbrella module; happy to follow up there if there's appetite.